### PR TITLE
feat: allow announce to be called on machine and notifier

### DIFF
--- a/GoDotNet.csproj
+++ b/GoDotNet.csproj
@@ -14,7 +14,7 @@
     <Company>Chickensoft</Company>
 
     <PackageId>Chickensoft.GoDotNet</PackageId>
-    <PackageVersion>1.2.0-beta8</PackageVersion>
+    <PackageVersion>1.3.0-beta8</PackageVersion>
     <PackageReleaseNotes>GoDotNet release.</PackageReleaseNotes>
     <PackageIcon></PackageIcon>
     <PackageTags>Godot;State Machine;Deterministic;Finite;FSM;Extensions;Notifier;Listener;Observable;Chickensoft;Gamedev;Utility;Utilities</PackageTags>

--- a/src/state/Machine.cs
+++ b/src/state/Machine.cs
@@ -147,5 +147,12 @@ public sealed class Machine<TState> : IReadOnlyMachine<TState>
     IsBusy = false;
   }
 
-  private void Announce() => OnChanged?.Invoke(State);
+  /// <summary>
+  /// Announces the current state to any listeners.
+  /// <see cref="Update"/> calls this automatically if the new state is
+  /// different from the previous state.
+  /// <br />
+  /// Call this whenever you want to force a re-announcement.
+  /// </summary>
+  public void Announce() => OnChanged?.Invoke(State);
 }

--- a/test/test/state/NotifierTest.cs
+++ b/test/test/state/NotifierTest.cs
@@ -11,6 +11,7 @@ public class NotifierTest : TestClass {
   public void Instantiates() {
     var notifier = new Notifier<string>("a");
     notifier.Value.ShouldBe("a");
+    notifier.Previous.ShouldBeNull();
   }
 
   [Test]
@@ -24,6 +25,7 @@ public class NotifierTest : TestClass {
     var notifier = new Notifier<string>("a", OnChanged);
     called.ShouldBeTrue();
     notifier.Value.ShouldBe("a");
+    notifier.Previous.ShouldBeNull();
   }
 
   [Test]
@@ -34,20 +36,30 @@ public class NotifierTest : TestClass {
     notifier.OnChanged += OnChanged;
     notifier.Update("a");
     called.ShouldBeFalse();
+    notifier.Previous.ShouldBeNull();
   }
 
   [Test]
   public void UpdatesValue() {
     var notifier = new Notifier<string>("a");
-    var called = false;
+    var calledOnChanged = false;
+    var calledOnUpdated = false;
     void OnChanged(string value, string? previous) {
-      called = true;
+      calledOnChanged = true;
       value.ShouldBe("b");
       previous.ShouldBe("a");
+      notifier.Previous.ShouldBe("a");
+    }
+    void OnUpdated(string value) {
+      calledOnUpdated = true;
+      value.ShouldBe("b");
+      notifier.Previous.ShouldBe("a");
     }
     notifier.OnChanged += OnChanged;
+    notifier.OnUpdated += OnUpdated;
     notifier.Update("b");
-    called.ShouldBeTrue();
+    calledOnChanged.ShouldBeTrue();
+    calledOnUpdated.ShouldBeTrue();
   }
 
 }


### PR DESCRIPTION
- Removes overly-complicated architecture recommendations from the readme. Learned a lot since then!
- Allows `Announce` to be called on `Machine` and `Notifier` to re-announce their current state or value, respectively.
- Adds a new event to Notifier, `OnUpdated`, which only receives the current value for the sake of convenience when you don't care about the previous value.